### PR TITLE
Fixes memory leak

### DIFF
--- a/src/SnapCam.cpp
+++ b/src/SnapCam.cpp
@@ -205,6 +205,7 @@ void SnapCam::onPreviewFrame(ICameraFrame *frame)
 	}
 
 	cb_(matFrame, time_stamp);
+    matFrame.deallocate();
 }
 
 int SnapCam::printCapabilities()


### PR DESCRIPTION
The data from matFrame is not properly freed when using snap_cam with Linaro 14.04 and OpenCV 3.1 on the Snapdragon Flight board. The problem may be present in additional distros. From #19 