### PR TITLE
Fix resolution parameter in launch files

### DIFF
--- a/launch/highres.launch
+++ b/launch/highres.launch
@@ -7,11 +7,11 @@
     <param name="camera_type" value="highres"/>
 
     <!--
-    highres:      QVGA  : (320, 240)
-                  VGA   : (640, 480)
-                  720p  : (1280, 720)
-                  1080p : (1920, 1080)
-                  4k    : (4096, 2160) -->
+    highres:      QVGA  : (320,240)
+                  VGA   : (640,480)
+                  720p  : (1280,720)
+                  1080p : (1920,1080)
+                  4k    : (4096,2160) -->
     <param name="camera_resolution" value="4k"/>
 
     <!--

--- a/launch/highres.launch
+++ b/launch/highres.launch
@@ -7,12 +7,12 @@
     <param name="camera_type" value="highres"/>
 
     <!--
-    highres:      0: QVGASize (320,240)
-                  1: VGASize (640,480)
-                  2: HDSize (1280,720)
-                  3: FHDSize (1920,1080)
-                  4: 4KSize (4096,2160) -->
-    <param name="camera_resolution" value="4"/>
+    highres:      QVGA  : (320, 240)
+                  VGA   : (640, 480)
+                  720p  : (1280, 720)
+                  1080p : (1920, 1080)
+                  4k    : (4096, 2160) -->
+    <param name="camera_resolution" value="4k"/>
 
     <!--
     highres: 0: 15 1: 24 2: 30 3: 60 4: 90 6: 120 -->

--- a/launch/optflow.launch
+++ b/launch/optflow.launch
@@ -7,9 +7,9 @@
     <param name="camera_type" value="optflow"/>
 
     <!--
-    optical flow: 0: QVGASize (320,240)
-                  1: VGASize (640,480) -->
-    <param name="camera_resolution" value="1"/>
+    optical flow: QVGA : (320,240)
+                  VGA  : (640,480) -->
+    <param name="camera_resolution" value="VGA"/>
 
     <!--
     optical flow: 0: 15, 1: 24, 2: 30, 3: 60, 4: 90, 5: 30, 6: 30 -->


### PR DESCRIPTION
The `highres.launch` and `optflow.launch` files use an index to specify camera resolution; however, in `snap_cam_publisher_node.cpp`, the expected value is a string. This pull request changes the value in the launch files (as well as the helper comments) to indicate the correct expected value.